### PR TITLE
Added enchant recipe for transfering charmable echants to separate books

### DIFF
--- a/src/main/java/cz/pmolek/enchantlevelx/EnchantLevelX.java
+++ b/src/main/java/cz/pmolek/enchantlevelx/EnchantLevelX.java
@@ -2,6 +2,7 @@ package cz.pmolek.enchantlevelx;
 
 import static java.lang.Integer.parseInt;
 
+import cz.pmolek.enchantlevelx.enchantdefinitions.CharmableEnchantTransferEnchant;
 import cz.pmolek.enchantlevelx.enchantdefinitions.CharmedBookUpgradeEnchantT2;
 import cz.pmolek.enchantlevelx.enchantdefinitions.CharmedBookUpgradeEnchantT3;
 import cz.pmolek.enchantlevelx.enchantdefinitions.EnchantedBookUpgradeEnchantT1;
@@ -71,6 +72,7 @@ public final class EnchantLevelX extends JavaPlugin
     enchanter.addEnchant(new CharmedBookUpgradeEnchantT3());
     enchanter.addEnchant(new ItemUpgradeWithCharmedBookEnchant());
     enchanter.addEnchant(new OverclockedItemUpgradeWithNormalBook());
+    enchanter.addEnchant(new CharmableEnchantTransferEnchant(enchanter));
     return enchanter;
   }
 

--- a/src/main/java/cz/pmolek/enchantlevelx/EnchantmentUtils.java
+++ b/src/main/java/cz/pmolek/enchantlevelx/EnchantmentUtils.java
@@ -54,6 +54,22 @@ public final class EnchantmentUtils {
   }
 
   /**
+   * Removes the specified enchantment from the given item.
+   *
+   * @param  item         the item from which to remove the enchantment
+   * @param  enchantment  the enchantment to be removed
+   */
+  public static void removeEnchantment(ItemStack item, Enchantment enchantment) {
+    if (item.getType() == Material.ENCHANTED_BOOK) {
+      EnchantmentStorageMeta meta = (EnchantmentStorageMeta) item.getItemMeta();
+      meta.removeStoredEnchant(enchantment);
+      item.setItemMeta(meta);
+    } else {
+      item.removeEnchantment(enchantment);
+    }
+  }
+
+  /**
    * Retrieves a list of enchantments from an item that satisfy a given predicate.
    *
    * @param item      the item to retrieve enchantments from

--- a/src/main/java/cz/pmolek/enchantlevelx/ItemUtils.java
+++ b/src/main/java/cz/pmolek/enchantlevelx/ItemUtils.java
@@ -1,7 +1,9 @@
 package cz.pmolek.enchantlevelx;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -14,9 +16,9 @@ public final class ItemUtils {
   /**
    * Check if the given item has specific custom model data.
    *
-   * @param  item            the ItemStack to check
-   * @param  customModelData the custom model data to compare against
-   * @return                 true if the ItemStack has the custom model data, false otherwise
+   * @param item            the ItemStack to check
+   * @param customModelData the custom model data to compare against
+   * @return true if the ItemStack has the custom model data, false otherwise
    */
   public static boolean hasCustomModelData(@Nullable ItemStack item, int customModelData) {
     return item != null
@@ -28,11 +30,11 @@ public final class ItemUtils {
   /**
    * Checks if the given item has a custom model data within the specified range.
    *
-   * @param  item                  the item to check
-   * @param  minCustomModelData    the minimum custom model data
-   * @param  maxCustomModelData    the maximum custom model data
-   * @return                       true if the item has a custom model data within the range,
-   *                               false otherwise
+   * @param item               the item to check
+   * @param minCustomModelData the minimum custom model data
+   * @param maxCustomModelData the maximum custom model data
+   * @return true if the item has a custom model data within the range,
+   *          false otherwise
    */
   public static boolean hasCustomModelDataInRange(@Nullable ItemStack item, int minCustomModelData,
                                                   int maxCustomModelData) {
@@ -57,5 +59,72 @@ public final class ItemUtils {
         CharmModelData.CHARM_III.modelData)
         && !hasCustomModelDataInRange(item, CharmModelData.CHARMED_BOOK_I.modelData,
         CharmModelData.CHARMED_BOOK_III.modelData);
+  }
+
+  /**
+   * Checks if the given item is of the specified material type.
+   *
+   * @param item     the item to check
+   * @param material the material type to compare against
+   * @return true if the item is of the specified material type, false otherwise
+   */
+  public static boolean isType(@Nullable ItemStack item, Material material) {
+    return item != null && item.getType() == material;
+  }
+
+  /**
+   * Returns a string representation of the given item, or an empty string if the item is null.
+   *
+   * @param  item  the ItemStack to convert to a string
+   * @return       a string representation of the item, or an empty string if the item is null
+   */
+  public static String toStringSafe(@Nullable ItemStack item) {
+    return item == null ? "" : item.toString();
+  }
+
+  /**
+   * Determines if two items are equal by their values.
+   *
+   * @implNote Compares type, amount and enchantments.
+   *
+   * @param  item1 the first ItemStack object
+   * @param  item2 the second ItemStack object
+   * @return true if the two ItemStack objects have the same values, false otherwise
+   */
+  public static boolean areEqualByValues(@Nullable ItemStack item1, @Nullable ItemStack item2) {
+    if (item1 == null || item2 == null) {
+      return item1 == item2;
+    }
+
+    if (item1.getType() != item2.getType()) {
+      return false;
+    }
+    if (item1.getAmount() != item2.getAmount()) {
+      return false;
+    }
+    if (!compareEnchants(EnchantmentUtils.getEnchantmentsUnsafe(item1),
+        EnchantmentUtils.getEnchantmentsUnsafe(item2))) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Compares two maps of enchantments and their corresponding levels.
+   *
+   * @param a the first map of enchantments and levels to compare
+   * @param b the second map of enchantments and levels to compare
+   * @return true if the maps are equal, false otherwise
+   */
+  public static boolean compareEnchants(Map<Enchantment, Integer> a, Map<Enchantment, Integer> b) {
+    for (Map.Entry<Enchantment, Integer> entry : a.entrySet()) {
+      if (!b.containsKey(entry.getKey())) {
+        return false;
+      }
+      if (!entry.getValue().equals(b.get(entry.getKey()))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/main/java/cz/pmolek/enchantlevelx/enchantdefinitions/CharmableEnchantTransferEnchant.java
+++ b/src/main/java/cz/pmolek/enchantlevelx/enchantdefinitions/CharmableEnchantTransferEnchant.java
@@ -1,0 +1,107 @@
+package cz.pmolek.enchantlevelx.enchantdefinitions;
+
+import cz.pmolek.enchantlevelx.CharmModelData;
+import cz.pmolek.enchantlevelx.EnchantmentUtils;
+import cz.pmolek.enchantlevelx.ItemUtils;
+import cz.pmolek.enchantlevelx.Tuple;
+import cz.pmolek.enchantlevelx.enchanter.AnvilEnchanter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Enchant for splitting enchantments between two books.
+ */
+public class CharmableEnchantTransferEnchant extends CharmEnchantBase {
+  private record State(@Nullable ItemStack source,
+                       @Nullable Tuple<Enchantment, Integer> enchant,
+                       @Nullable ItemStack result) {
+    public static State getEmpty() {
+      return new State(null, null, null);
+    }
+  }
+
+  private final Map<UUID, State> inProgressEnchants = new HashMap<>();
+  private final AnvilEnchanter enchanter;
+
+  public CharmableEnchantTransferEnchant(AnvilEnchanter enchanter) {
+    this.enchanter = enchanter;
+  }
+
+  @Override
+  public String getId() {
+    return CharmableEnchantTransferEnchant.class.getName();
+  }
+
+  @Override
+  public boolean validateInput(@Nullable ItemStack left, @Nullable ItemStack right,
+                               @Nullable ItemStack result) {
+    return left == null
+        || (result == null
+            && (ItemUtils.isEnchantedBook(left) || CharmModelData.isCharmedBook(left))
+            && ItemUtils.isType(right, Material.BOOK)
+            && !EnchantmentUtils.getEnchantmentsThat(left, this::isValidEnchantment).isEmpty());
+  }
+
+  @Override
+  public ItemStack enchant(ItemStack left, ItemStack right, PrepareAnvilEvent eventData) {
+    HumanEntity sender = eventData.getViewers().get(0);
+    State state = inProgressEnchants.getOrDefault(sender.getUniqueId(), State.getEmpty());
+
+    //Reset
+    if (left == null) {
+      //Transaction finished, return original book without enchant
+      if (state.result != null && state.source != null && state.enchant != null) {
+        AnvilInventory inventory = eventData.getInventory();
+        ItemStack source = state.source;
+        EnchantmentUtils.removeEnchantment(source, state.enchant.getValueA());
+        enchanter.ignoreNextEventFrom(sender);
+        inventory.setItem(0, source);
+      }
+      state = State.getEmpty();
+      inProgressEnchants.put(sender.getUniqueId(), state);
+      return eventData.getResult();
+    }
+    //Result already evaluated
+    if (state.result != null) {
+      return state.result;
+    }
+    //Source already evaluated
+    if (ItemUtils.areEqualByValues(state.source, left)) {
+      return eventData.getResult();
+    } else { //Start new state
+      state = new State(left, null, null);
+      inProgressEnchants.put(sender.getUniqueId(), state);
+    }
+
+    ItemStack result = new ItemStack(Material.ENCHANTED_BOOK, 1);
+
+    ItemMeta meta = result.getItemMeta();
+    meta.setDisplayName(eventData.getInventory().getRenameText());
+    result.setItemMeta(meta);
+
+    List<Tuple<Enchantment, Integer>> enchants = EnchantmentUtils
+        .getEnchantmentsThat(left, this::isValidEnchantment);
+    EnchantmentUtils
+        .addEnchantmentUnsafe(result, enchants.get(0).getValueA(), enchants.get(0).getValueB());
+
+    state = new State(left, enchants.get(0), result);
+    inProgressEnchants.put(sender.getUniqueId(), state);
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public Integer getEnchantmentCost(ItemStack left, ItemStack right) {
+    return 3;
+  }
+}

--- a/src/main/java/cz/pmolek/enchantlevelx/enchanter/AnvilEnchanter.java
+++ b/src/main/java/cz/pmolek/enchantlevelx/enchanter/AnvilEnchanter.java
@@ -2,8 +2,12 @@ package cz.pmolek.enchantlevelx.enchanter;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nullable;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -15,6 +19,7 @@ import org.bukkit.inventory.ItemStack;
  */
 public class AnvilEnchanter implements Listener {
   private final Map<String, AnvilEnchantDefinition> enchants = new HashMap<>();
+  private final Set<UUID> ignoredPlayers = new HashSet<>();
 
   /**
    * Adds an AnvilEnchantDefinition to the enchants map.
@@ -43,6 +48,10 @@ public class AnvilEnchanter implements Listener {
     enchants.remove(id);
   }
 
+  public void ignoreNextEventFrom(HumanEntity player) {
+    ignoredPlayers.add(player.getUniqueId());
+  }
+
   /**
    * This function is an event handler that is called when the PrepareAnvilEvent is triggered.
    * It retrieves the items in the anvil, finds the appropriate enchantment to apply,
@@ -52,6 +61,11 @@ public class AnvilEnchanter implements Listener {
    */
   @EventHandler
   public void onPrepareAnvil(PrepareAnvilEvent event) {
+    HumanEntity sender = event.getViewers().get(0);
+    if (ignoredPlayers.contains(sender.getUniqueId())) {
+      ignoredPlayers.remove(sender.getUniqueId());
+      return;
+    }
     // Get items in anvil
     ItemStack left = event.getInventory().getItem(0);
     ItemStack right = event.getInventory().getItem(1);


### PR DESCRIPTION
Added CharmableEnchantTransferEnchant for transfering a charmable enchant to a dedicated regular book to prevet player being deadlocked from upgrading

Added ItemUtils.areEqualByValues to compare items by value Added EnchantmentUtils.removeEnchantment for removing enchants Documentation fixes